### PR TITLE
python compatibility and style guideline changes

### DIFF
--- a/01-getdata.html
+++ b/01-getdata.html
@@ -85,10 +85,10 @@ Cleaning up...</code></pre>
 url = <span class="st">&#39;http://climatedataapi.worldbank.org/climateweb/rest/v1/country/cru/tas/year/CAN.csv&#39;</span>
 response = requests.get(url)
 <span class="kw">if</span> response.status_code != <span class="dv">200</span>:
-    <span class="dt">print</span> <span class="st">&#39;Failed to get data:&#39;</span>, response.status_code
+    <span class="dt">print</span>(<span class="st">&#39;Failed to get data:&#39;</span>, response.status_code)
 <span class="kw">else</span>:
-    <span class="dt">print</span> <span class="st">&#39;First 100 characters of data are&#39;</span>
-    <span class="dt">print</span> response.text[:<span class="dv">100</span>]</code></pre>
+    <span class="dt">print</span>(<span class="st">&#39;First 100 characters of data are&#39;</span>)
+    <span class="dt">print</span>(response.text[:<span class="dv">100</span>])</code></pre>
 <pre class="output"><code>First 100 characters of data are
 year,data
 1901,-7.67241907119751

--- a/01-getdata.md
+++ b/01-getdata.md
@@ -93,10 +93,10 @@ import requests
 url = 'http://climatedataapi.worldbank.org/climateweb/rest/v1/country/cru/tas/year/CAN.csv'
 response = requests.get(url)
 if response.status_code != 200:
-    print 'Failed to get data:', response.status_code
+    print('Failed to get data:', response.status_code)
 else:
-    print 'First 100 characters of data are'
-    print response.text[:100]
+    print('First 100 characters of data are')
+    print(response.text[:100])
 ~~~
 ~~~ {.output}
 First 100 characters of data are

--- a/02-csv.html
+++ b/02-csv.html
@@ -50,14 +50,14 @@
 <span class="st">1903,78.9&#39;&#39;&#39;</span>
 
 as_lines = input_data.split(<span class="st">&#39;</span><span class="ch">\n</span><span class="st">&#39;</span>)
-<span class="dt">print</span> <span class="st">&#39;input data as lines:&#39;</span>
-<span class="dt">print</span> as_lines
+<span class="dt">print</span>(<span class="st">&#39;input data as lines:&#39;</span>)
+<span class="dt">print</span>(as_lines)
 
 <span class="kw">for</span> line in as_lines:
     fields = line.split(<span class="st">&#39;,&#39;</span>) <span class="co"># turn &#39;1901,12.3&#39; into [&#39;1901&#39;, &#39;12.3&#39;]</span>
     year = <span class="dt">int</span>(fields[<span class="dv">0</span>])    <span class="co"># turn the text &#39;1901&#39; into the integer 1901</span>
     value = <span class="dt">float</span>(fields[<span class="dv">1</span>]) <span class="co"># turn the text &#39;12.3&#39; into the number 12.3</span>
-    <span class="dt">print</span> year, <span class="st">&#39;:&#39;</span>, value</code></pre>
+    <span class="dt">print</span>(year, <span class="st">&#39;:&#39;</span>, value)</code></pre>
 <pre class="output"><code>input data as lines:
 [&#39;1901,12.3&#39;, &#39;1902,45.6&#39;, &#39;1903,78.9&#39;]
 1901 : 12.3
@@ -72,55 +72,35 @@ as_lines = input_data.split(<span class="st">&#39;</span><span class="ch">\n</sp
 <p>Programmers need a way to put quotes, double quotes, and other special characters in strings. To do this, they use <a href="reference.html#escape-sequence">escape sequences</a>: <code>\'</code> for a single quote, <code>\&quot;</code> for a double quote, <code>\n</code> for a newline, and so on.</p>
 </div>
 </div>
-<p>Now let’s have a look at how we could parse the data using a couple of standard Python libraries. The first, called <code>cStringIO</code>, lets Python treat a string as if it was an input file:</p>
-<pre class="sourceCode python"><code class="sourceCode python"><span class="ch">import</span> cStringIO
-
-data = <span class="st">&#39;&#39;&#39;first</span>
-<span class="st">second</span>
-<span class="st">third&#39;&#39;&#39;</span>
-
-reader = cStringIO.StringIO(data)
-<span class="kw">for</span> line in reader:
-    <span class="dt">print</span> line</code></pre>
-<pre class="output"><code>first
-
-second
-
-third</code></pre>
-<p>The <code>cStringIO.StringIO</code> object that we assign to <code>reader</code> is an object that behaves like a file, but reads characters from a string instead of from something on our hard drive. As we’ll see in the exercises, we can also write to a <code>StringIO</code> object, which is very useful when we’re testing programs.</p>
-<div id="why-the-c" class="callout panel panel-info">
-<div class="panel-heading">
-<h2><span class="glyphicon glyphicon-pushpin"></span>Why the ‘c’?</h2>
-</div>
-<div class="panel-body">
-<p>The ‘c’ at the start of <code>cStringIO</code>’s name comes from the fact that it is a rewrite in C of an older and slower library called <code>StringIO</code>.</p>
-</div>
-</div>
-<p>The second library we’ll use is called <code>csv</code>. It doesn’t read data itself: instead, it takes the lines read by something else and turns them into lists of values by splitting on commas:</p>
+<p>Now let’s have a look at how we could parse the data using standard Python libraries. The library we’ll use is called <code>csv</code>. It doesn’t read data itself: instead, it takes the lines read by something else and turns them into lists of values by splitting on commas. We will also need to split the string on line separators before <code>csv</code> can read it:</p>
 <pre class="sourceCode python"><code class="sourceCode python"><span class="ch">import</span> csv
+<span class="ch">import</span> io
 
-data = <span class="st">&#39;&#39;&#39;first,FIRST</span>
+data = <span class="st">u&#39;&#39;&#39;first,FIRST</span>
 <span class="st">second,SECOND</span>
 <span class="st">third,THIRD&#39;&#39;&#39;</span>
-reader = cStringIO.StringIO(data)
+reader = io.StringIO(data)
 wrapper = csv.reader(reader)
 <span class="kw">for</span> record in wrapper:
-    <span class="dt">print</span> record</code></pre>
+    <span class="dt">print</span>(record)</code></pre>
 <pre class="output"><code>[&#39;first&#39;, &#39;FIRST&#39;]
 [&#39;second&#39;, &#39;SECOND&#39;]
 [&#39;third&#39;, &#39;THIRD&#39;]</code></pre>
 <p>Putting it all together, we can get data for Canada like this:</p>
-<pre class="sourceCode python"><code class="sourceCode python">url = <span class="st">&#39;http://climatedataapi.worldbank.org/climateweb/rest/v1/country/cru/tas/year/CAN.csv&#39;</span>
+<pre class="sourceCode python"><code class="sourceCode python"><span class="ch">import</span> requests
+<span class="ch">import</span> io
+<span class="ch">import</span> csv
+url = <span class="st">&#39;http://climatedataapi.worldbank.org/climateweb/rest/v1/country/cru/tas/year/CAN.csv&#39;</span>
 response = requests.get(url)
 <span class="kw">if</span> response.status_code != <span class="dv">200</span>:
-    <span class="dt">print</span> <span class="st">&#39;Failed to get data:&#39;</span>, response.status_code
+    <span class="dt">print</span>(<span class="st">&#39;Failed to get data:&#39;</span>, response.status_code)
 <span class="kw">else</span>:
-    reader = cStringIO.StringIO(response.text)
+    reader = io.StringIO(response.text)
     wrapper = csv.reader(reader)
     <span class="kw">for</span> record in wrapper:
         year = <span class="dt">int</span>(record[<span class="dv">0</span>])
         value = <span class="dt">float</span>(record[<span class="dv">1</span>])
-        <span class="dt">print</span> year, <span class="st">&#39;:&#39;</span>, value</code></pre>
+        <span class="dt">print</span>(year, <span class="st">&#39;:&#39;</span>, value)</code></pre>
 <pre class="error"><code>---------------------------------------------------------------------------
 ValueError                                Traceback (most recent call last)
 &lt;ipython-input-6-da21db395042&gt; in &lt;module&gt;()
@@ -134,12 +114,16 @@ ValueError: invalid literal for int() with base 10: &#39;year&#39;</code></pre>
 <p>That error occurs because the first line of data is:</p>
 <pre><code>year,data</code></pre>
 <p>When we try to convert the string <code>'year'</code> to an integer, Python quite rightly complains. The fix is straightforward: we just need to ignore lines that start with the word <code>year</code>. And while we’re at it, we’ll put our results into a list instead of just printing them:</p>
-<pre class="sourceCode python"><code class="sourceCode python">url = <span class="st">&#39;http://climatedataapi.worldbank.org/climateweb/rest/v1/country/cru/tas/year/CAN.csv&#39;</span>
+<pre class="sourceCode python"><code class="sourceCode python"><span class="ch">import</span> requests
+<span class="ch">import</span> io
+<span class="ch">import</span> csv
+
+url = <span class="st">&#39;http://climatedataapi.worldbank.org/climateweb/rest/v1/country/cru/tas/year/CAN.csv&#39;</span>
 response = requests.get(url)
 <span class="kw">if</span> response.status_code != <span class="dv">200</span>:
-    <span class="dt">print</span> <span class="st">&#39;Failed to get data:&#39;</span>, response.status_code
+    <span class="dt">print</span>(<span class="st">&#39;Failed to get data:&#39;</span>, response.status_code)
 <span class="kw">else</span>:
-    reader = cStringIO.StringIO(response.text)
+    reader = io.StringIO(response.text)
     wrapper = csv.reader(reader)
     results = []
     <span class="kw">for</span> record in wrapper:
@@ -147,21 +131,10 @@ response = requests.get(url)
             year = <span class="dt">int</span>(record[<span class="dv">0</span>])
             value = <span class="dt">float</span>(record[<span class="dv">1</span>])
             results.append([year, value])
-    <span class="dt">print</span> <span class="st">&#39;first five results&#39;</span>
-    <span class="dt">print</span> results[:<span class="dv">5</span>]</code></pre>
+    <span class="dt">print</span>(<span class="st">&#39;first five results&#39;</span>)
+    <span class="dt">print</span>(results[:<span class="dv">5</span>])</code></pre>
 <pre class="output"><code>first five results
 [[1901, -7.67241907119751], [1902, -7.862711429595947], [1903, -7.910782814025879], [1904, -8.155729293823242], [1905, -7.547311305999756]]</code></pre>
-<div id="writing-to-strings" class="challenge panel panel-success">
-<div class="panel-heading">
-<h2><span class="glyphicon glyphicon-pencil"></span>Writing to Strings</h2>
-</div>
-<div class="panel-body">
-<p><code>cStringIO</code> can also be used for output. Use this to write a test that the function <code>print_count</code> does the right thing:</p>
-<pre class="sourceCode python"><code class="sourceCode python"><span class="kw">def</span> print_count(output, num):
-    <span class="kw">for</span> i in <span class="dt">range</span>(num):
-        <span class="dt">print</span> &gt;&gt; output, num</code></pre>
-</div>
-</div>
         </div>
       </div>
       </article>

--- a/02-csv.md
+++ b/02-csv.md
@@ -30,14 +30,14 @@ input_data = '''1901,12.3
 1903,78.9'''
 
 as_lines = input_data.split('\n')
-print 'input data as lines:'
-print as_lines
+print('input data as lines:')
+print(as_lines)
 
 for line in as_lines:
     fields = line.split(',') # turn '1901,12.3' into ['1901', '12.3']
     year = int(fields[0])    # turn the text '1901' into the integer 1901
     value = float(fields[1]) # turn the text '12.3' into the number 12.3
-    print year, ':', value
+    print(year, ':', value)
 ~~~
 ~~~ {.output}
 input data as lines:
@@ -59,53 +59,21 @@ by splitting the line on the comma and converting the digits to numbers.
 To do this, they use [escape sequences](reference.html#escape-sequence):
 > `\'` for a single quote, `\"` for a double quote, `\n` for a newline, and so on.
 
-Now let's have a look at how we could parse the data using a couple of standard Python libraries.
-The first,
-called `cStringIO`, lets Python treat a string as if it was an input file:
-
-~~~ {.python}
-import cStringIO
-
-data = '''first
-second
-third'''
-
-reader = cStringIO.StringIO(data)
-for line in reader:
-    print line
-~~~
-~~~ {.output}
-first
-
-second
-
-third
-~~~
-
-The `cStringIO.StringIO` object that we assign to `reader` is an object that behaves like a file,
-but reads characters from a string instead of from something on our hard drive.
-As we'll see in the exercises,
-we can also write to a `StringIO` object,
-which is very useful when we're testing programs.
-
-> ## Why the 'c'? {.callout}
->
-> The 'c' at the start of `cStringIO`'s name comes from the fact that it is a rewrite in C of an older and slower library called `StringIO`.
-
-The second library we'll use is called `csv`.
+Now let's have a look at how we could parse the data using standard Python libraries.  The library we'll use is called `csv`.
 It doesn't read data itself:
-instead, it takes the lines read by something else and turns them into lists of values by splitting on commas:
+instead, it takes the lines read by something else and turns them into lists of values by splitting on commas. We will also need to split the string on line separators before `csv` can read it:
 
 ~~~ {.python}
 import csv
+import io
 
-data = '''first,FIRST
+data = u'''first,FIRST
 second,SECOND
 third,THIRD'''
-reader = cStringIO.StringIO(data)
+reader = io.StringIO(data)
 wrapper = csv.reader(reader)
 for record in wrapper:
-    print record
+    print(record)
 ~~~
 ~~~ {.output}
 ['first', 'FIRST']
@@ -116,17 +84,20 @@ for record in wrapper:
 Putting it all together, we can get data for Canada like this:
 
 ~~~ {.python}
+import requests
+import io
+import csv
 url = 'http://climatedataapi.worldbank.org/climateweb/rest/v1/country/cru/tas/year/CAN.csv'
 response = requests.get(url)
 if response.status_code != 200:
-    print 'Failed to get data:', response.status_code
+    print('Failed to get data:', response.status_code)
 else:
-    reader = cStringIO.StringIO(response.text)
+    reader = io.StringIO(response.text)
     wrapper = csv.reader(reader)
     for record in wrapper:
         year = int(record[0])
         value = float(record[1])
-        print year, ':', value
+        print(year, ':', value)
 ~~~
 ~~~ {.error}
 ---------------------------------------------------------------------------
@@ -155,12 +126,16 @@ And while we're at it,
 we'll put our results into a list instead of just printing them:
 
 ~~~ {.python}
+import requests
+import io
+import csv
+
 url = 'http://climatedataapi.worldbank.org/climateweb/rest/v1/country/cru/tas/year/CAN.csv'
 response = requests.get(url)
 if response.status_code != 200:
-    print 'Failed to get data:', response.status_code
+    print('Failed to get data:', response.status_code)
 else:
-    reader = cStringIO.StringIO(response.text)
+    reader = io.StringIO(response.text)
     wrapper = csv.reader(reader)
     results = []
     for record in wrapper:
@@ -168,21 +143,11 @@ else:
             year = int(record[0])
             value = float(record[1])
             results.append([year, value])
-    print 'first five results'
-    print results[:5]
+    print('first five results')
+    print(results[:5])
 ~~~
 ~~~ {.output}
 first five results
 [[1901, -7.67241907119751], [1902, -7.862711429595947], [1903, -7.910782814025879], [1904, -8.155729293823242], [1905, -7.547311305999756]]
 ~~~
 
-> ## Writing to Strings {.challenge}
->
-> `cStringIO` can also be used for output.
-> Use this to write a test that the function `print_count` does the right thing:
->
-> ~~~ {.python}
-> def print_count(output, num):
->     for i in range(num):
->         print >> output, num
-> ~~~

--- a/02-csv.md
+++ b/02-csv.md
@@ -65,13 +65,12 @@ instead, it takes the lines read by something else and turns them into lists of 
 
 ~~~ {.python}
 import csv
-import io
+import os
 
-data = u'''first,FIRST
+data = '''first,FIRST
 second,SECOND
 third,THIRD'''
-reader = io.StringIO(data)
-wrapper = csv.reader(reader)
+wrapper = csv.reader(data.strip().split(os.linesep))
 for record in wrapper:
     print(record)
 ~~~
@@ -85,15 +84,14 @@ Putting it all together, we can get data for Canada like this:
 
 ~~~ {.python}
 import requests
-import io
+import os
 import csv
 url = 'http://climatedataapi.worldbank.org/climateweb/rest/v1/country/cru/tas/year/CAN.csv'
 response = requests.get(url)
 if response.status_code != 200:
     print('Failed to get data:', response.status_code)
 else:
-    reader = io.StringIO(response.text)
-    wrapper = csv.reader(reader)
+    wrapper = csv.reader(response.text.strip().split(os.linesep))
     for record in wrapper:
         year = int(record[0])
         value = float(record[1])
@@ -127,7 +125,7 @@ we'll put our results into a list instead of just printing them:
 
 ~~~ {.python}
 import requests
-import io
+import os
 import csv
 
 url = 'http://climatedataapi.worldbank.org/climateweb/rest/v1/country/cru/tas/year/CAN.csv'
@@ -135,8 +133,7 @@ response = requests.get(url)
 if response.status_code != 200:
     print('Failed to get data:', response.status_code)
 else:
-    reader = io.StringIO(response.text)
-    wrapper = csv.reader(reader)
+    wrapper = csv.reader(response.text.strip().split(os.linesep))
     results = []
     for record in wrapper:
         if record[0] != 'year':

--- a/03-generalize.html
+++ b/03-generalize.html
@@ -45,9 +45,9 @@
     url = <span class="st">&#39;http://climatedataapi.worldbank.org/climateweb/rest/v1/country/cru/tas/year/&#39;</span> + country + <span class="st">&#39;.csv&#39;</span>
     response = requests.get(url)
     <span class="kw">if</span> response.status_code != <span class="dv">200</span>:
-        <span class="dt">print</span> <span class="st">&#39;Failed to get data:&#39;</span>, response.status_code
+        <span class="dt">print</span>(<span class="st">&#39;Failed to get data:&#39;</span>, response.status_code)
     <span class="kw">else</span>:
-        reader = cStringIO.StringIO(response.text)
+        reader = io.StringIO(response.text)
         wrapper = csv.reader(reader)
         results = []
         <span class="kw">for</span> record in wrapper:
@@ -58,7 +58,7 @@
         <span class="kw">return</span> results</code></pre>
 <p>This works:</p>
 <pre class="sourceCode python"><code class="sourceCode python">canada = get_annual_mean_temp_by_country(<span class="st">&#39;CAN&#39;</span>)
-<span class="dt">print</span> <span class="st">&#39;first five entries for Canada:&#39;</span>, canada[:<span class="dv">5</span>]</code></pre>
+<span class="dt">print</span>(<span class="st">&#39;first five entries for Canada:&#39;</span>, canada[:<span class="dv">5</span>])</code></pre>
 <pre class="output"><code>first five entries for Canada: [[1901, -7.67241907119751], [1902, -7.862711429595947], [1903, -7.910782814025879], [1904, -8.155729293823242], [1905, -7.547311305999756]]</code></pre>
 <p>but there’s a problem. Look what happens when we pass in an invalid country identifier:</p>
 <pre class="sourceCode python"><code class="sourceCode python">latveria = get_annual_mean_temp_by_country(<span class="st">&#39;LTV&#39;</span>)
@@ -68,14 +68,14 @@
 <pre class="sourceCode python"><code class="sourceCode python"><span class="kw">def</span> get_annual_mean_temp_by_country(country):
     <span class="co">&#39;&#39;&#39;Get the annual mean temperature for a country given its 3-letter ISO code (such as &quot;CAN&quot;).&#39;&#39;&#39;</span>
     url = <span class="st">&#39;http://climatedataapi.worldbank.org/climateweb/rest/v1/country/cru/tas/year/&#39;</span> + country + <span class="st">&#39;.csv&#39;</span>
-    <span class="dt">print</span> <span class="st">&#39;url used is&#39;</span>, url
+    <span class="dt">print</span>(<span class="st">&#39;url used is&#39;</span>, url)
     response = requests.get(url)
-    <span class="dt">print</span> <span class="st">&#39;response code:&#39;</span>, response.status_code
-    <span class="dt">print</span> <span class="st">&#39;length of data:&#39;</span>, <span class="dt">len</span>(response.text)
+    <span class="dt">print</span>(<span class="st">&#39;response code:&#39;</span>, response.status_code)
+    <span class="dt">print</span>(<span class="st">&#39;length of data:&#39;</span>, <span class="dt">len</span>(response.text))
     <span class="kw">if</span> response.status_code != <span class="dv">200</span>:
-        <span class="dt">print</span> <span class="st">&#39;Failed to get data:&#39;</span>, response.status_code
+        <span class="dt">print</span>(<span class="st">&#39;Failed to get data:&#39;</span>, response.status_code)
     <span class="kw">else</span>:
-        reader = cStringIO.StringIO(response.text)
+        reader = io.StringIO(response.text)
         wrapper = csv.reader(reader)
         results = []
         <span class="kw">for</span> record in wrapper:
@@ -86,7 +86,7 @@
         <span class="kw">return</span> results
 
 latveria = get_annual_mean_temp_by_country(<span class="st">&#39;LTV&#39;</span>)
-<span class="dt">print</span> <span class="st">&#39;number of records for Latveria:&#39;</span>, <span class="dt">len</span>(latveria)</code></pre>
+<span class="dt">print</span>(<span class="st">&#39;number of records for Latveria:&#39;</span>, <span class="dt">len</span>(latveria))</code></pre>
 <pre class="output"><code>url used is http://climatedataapi.worldbank.org/climateweb/rest/v1/country/cru/tas/year/LTV.csv
 response code: 200
 length of data: 0
@@ -101,7 +101,7 @@ number of records for Latveria: 0</code></pre>
     response = requests.get(url)
     results = []
     <span class="kw">if</span> <span class="dt">len</span>(response.text) &gt; <span class="dv">0</span>:
-        reader = cStringIO.StringIO(response.text)
+        reader = io.StringIO(response.text)
         wrapper = csv.reader(reader)
         <span class="kw">for</span> record in wrapper:
             <span class="kw">if</span> record[<span class="dv">0</span>] != <span class="st">&#39;year&#39;</span>:
@@ -110,8 +110,8 @@ number of records for Latveria: 0</code></pre>
                 results.append([year, value])
     <span class="kw">return</span> results
 
-<span class="dt">print</span> <span class="st">&#39;number of records for Canada:&#39;</span>, <span class="dt">len</span>(get_annual_mean_temp_by_country(<span class="st">&#39;CAN&#39;</span>))
-<span class="dt">print</span> <span class="st">&#39;number of records for Latveria:&#39;</span>, <span class="dt">len</span>(get_annual_mean_temp_by_country(<span class="st">&#39;LTV&#39;</span>))</code></pre>
+<span class="dt">print</span>(<span class="st">&#39;number of records for Canada:&#39;</span>, <span class="dt">len</span>(get_annual_mean_temp_by_country(<span class="st">&#39;CAN&#39;</span>)))
+<span class="dt">print</span>(<span class="st">&#39;number of records for Latveria:&#39;</span>, <span class="dt">len</span>(get_annual_mean_temp_by_country(<span class="st">&#39;LTV&#39;</span>)))</code></pre>
 <pre class="output"><code>number of records for Canada: 109
 number of records for Latveria: 0</code></pre>
 <p>Now that we can get surface temperatures for different countries, we can write a function to compare those values. (We’ll jump straight into writing a function because by now it’s clear that’s what we’re eventually going to do anyway.) Here’s our first cut:</p>
@@ -129,25 +129,25 @@ number of records for Latveria: 0</code></pre>
 <pre class="sourceCode python"><code class="sourceCode python"><span class="kw">for</span> i in <span class="dt">range</span>(num_years):</code></pre>
 <p>runs <code>i</code> from 0 to <code>num_years-1</code>, which corresponds exactly to the legal indices of <code>left</code>. Inside the loop we unpack the left and right years and values from the list entries, then append a pair containing a year and a difference to <code>results</code>, which we return at the end.</p>
 <p>To see if this function works, we can run a couple of tests on made-up data:</p>
-<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span> <span class="st">&#39;one record:&#39;</span>, diff_records([[<span class="dv">1900</span>, <span class="fl">1.0</span>]],
-                                  [[<span class="dv">1900</span>, <span class="fl">2.0</span>]])
-<span class="dt">print</span> <span class="st">&#39;two records:&#39;</span>, diff_records([[<span class="dv">1900</span>, <span class="fl">1.0</span>], [<span class="dv">1901</span>, <span class="fl">10.0</span>]],
-                                   [[<span class="dv">1900</span>, <span class="fl">2.0</span>], [<span class="dv">1901</span>, <span class="fl">20.0</span>]])</code></pre>
+<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span>(<span class="st">&#39;one record:&#39;</span>, diff_records([[<span class="dv">1900</span>, <span class="fl">1.0</span>]],
+                                  [[<span class="dv">1900</span>, <span class="fl">2.0</span>]]))
+<span class="dt">print</span>(<span class="st">&#39;two records:&#39;</span>, diff_records([[<span class="dv">1900</span>, <span class="fl">1.0</span>], [<span class="dv">1901</span>, <span class="fl">10.0</span>]],
+                                   [[<span class="dv">1900</span>, <span class="fl">2.0</span>], [<span class="dv">1901</span>, <span class="fl">20.0</span>]]))</code></pre>
 <pre class="output"><code>one record: [[1900, -1.0]]
 two records: [[1900, -1.0], [1901, -10.0]]</code></pre>
 <p>That looks pretty good—but what about these cases?</p>
-<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span> <span class="st">&#39;mis-matched years:&#39;</span>, diff_records([[<span class="dv">1900</span>, <span class="fl">1.0</span>]],
-                                         [[<span class="dv">1999</span>, <span class="fl">2.0</span>]])
-<span class="dt">print</span> <span class="st">&#39;left is shorter&#39;</span>, diff_records([[<span class="dv">1900</span>, <span class="fl">1.0</span>]],
-                                      [[<span class="dv">1900</span>, <span class="fl">10.0</span>], [<span class="dv">1901</span>, <span class="fl">20.0</span>]])
-<span class="dt">print</span> <span class="st">&#39;right is shorter&#39;</span>, diff_records([[<span class="dv">1900</span>, <span class="fl">1.0</span>], [<span class="dv">1901</span>, <span class="fl">2.0</span>]],
-                                       [[<span class="dv">1900</span>, <span class="fl">10.0</span>]])</code></pre>
+<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span>(<span class="st">&#39;mis-matched years:&#39;</span>, diff_records([[<span class="dv">1900</span>, <span class="fl">1.0</span>]],
+                                         [[<span class="dv">1999</span>, <span class="fl">2.0</span>]]))
+<span class="dt">print</span>(<span class="st">&#39;left is shorter&#39;</span>, diff_records([[<span class="dv">1900</span>, <span class="fl">1.0</span>]],
+                                      [[<span class="dv">1900</span>, <span class="fl">10.0</span>], [<span class="dv">1901</span>, <span class="fl">20.0</span>]]))
+<span class="dt">print</span>(<span class="st">&#39;right is shorter&#39;</span>, diff_records([[<span class="dv">1900</span>, <span class="fl">1.0</span>], [<span class="dv">1901</span>, <span class="fl">2.0</span>]],
+                                       [[<span class="dv">1900</span>, <span class="fl">10.0</span>]]))</code></pre>
 <pre class="error"><code>---------------------------------------------------------------------------
 IndexError                                Traceback (most recent call last)
 &lt;ipython-input-15-7582f56db8bf&gt; in &lt;module&gt;()
       4                                       [[1900, 10.0], [1901, 20.0]])
-      5 print &#39;right is shorter&#39;, diff_records([[1900, 1.0], [1901, 2.0]],
-----&gt; 6                                        [[1900, 10.0]])
+      5 print(&#39;right is shorter&#39;, diff_records([[1900, 1.0], [1901, 2.0]],
+----&gt; 6                                        [[1900, 10.0]]))
 
 &lt;ipython-input-13-67464343fd99&gt; in diff_records(left, right)
       5     for i in range(num_years):
@@ -179,20 +179,20 @@ right is shorter</code></pre>
         results.append([left_year, difference])
     <span class="kw">return</span> results</code></pre>
 <p>Do our “good” tests pass?</p>
-<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span> <span class="st">&#39;one record:&#39;</span>, diff_records([[<span class="dv">1900</span>, <span class="fl">1.0</span>]],
-                                  [[<span class="dv">1900</span>, <span class="fl">2.0</span>]])
-<span class="dt">print</span> <span class="st">&#39;two records:&#39;</span>, diff_records([[<span class="dv">1900</span>, <span class="fl">1.0</span>], [<span class="dv">1901</span>, <span class="fl">10.0</span>]],
-                                   [[<span class="dv">1900</span>, <span class="fl">2.0</span>], [<span class="dv">1901</span>, <span class="fl">20.0</span>]])</code></pre>
+<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span>(<span class="st">&#39;one record:&#39;</span>, diff_records([[<span class="dv">1900</span>, <span class="fl">1.0</span>]],
+                                  [[<span class="dv">1900</span>, <span class="fl">2.0</span>]]))
+<span class="dt">print</span>(<span class="st">&#39;two records:&#39;</span>, diff_records([[<span class="dv">1900</span>, <span class="fl">1.0</span>], [<span class="dv">1901</span>, <span class="fl">10.0</span>]],
+                                   [[<span class="dv">1900</span>, <span class="fl">2.0</span>], [<span class="dv">1901</span>, <span class="fl">20.0</span>]]))</code></pre>
 <pre class="output"><code>one record: [[1900, -1.0]]
 two records: [[1900, -1.0], [1901, -10.0]]</code></pre>
 <p>What about our the three tests that we now expect to fail?</p>
-<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span> <span class="st">&#39;mis-matched years:&#39;</span>, diff_records([[<span class="dv">1900</span>, <span class="fl">1.0</span>]],
-                                         [[<span class="dv">1999</span>, <span class="fl">2.0</span>]])</code></pre>
+<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span>(<span class="st">&#39;mis-matched years:&#39;</span>, diff_records([[<span class="dv">1900</span>, <span class="fl">1.0</span>]],
+                                         [[<span class="dv">1999</span>, <span class="fl">2.0</span>]]))</code></pre>
 <pre class="error"><code>---------------------------------------------------------------------------
 AssertionError                            Traceback (most recent call last)
 &lt;ipython-input-18-c101917a748e&gt; in &lt;module&gt;()
-      1 print &#39;mis-matched years:&#39;, diff_records([[1900, 1.0]],
-----&gt; 2                                          [[1999, 2.0]])
+      1 print(&#39;mis-matched years:&#39;, diff_records([[1900, 1.0]],
+----&gt; 2                                          [[1999, 2.0]]))
 
 &lt;ipython-input-16-d41327791c15&gt; in diff_records(left, right)
      10         left_year, left_value = left[i]
@@ -202,13 +202,13 @@ AssertionError                            Traceback (most recent call last)
      14         results.append([left_year, difference])
 
 AssertionError: Record 0 is for different years: 1900 vs 1999mis-matched years:</code></pre>
-<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span> <span class="st">&#39;left is shorter&#39;</span>, diff_records([[<span class="dv">1900</span>, <span class="fl">1.0</span>]],
-                                      [[<span class="dv">1900</span>, <span class="fl">10.0</span>], [<span class="dv">1901</span>, <span class="fl">20.0</span>]])</code></pre>
+<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span>(<span class="st">&#39;left is shorter&#39;</span>, diff_records([[<span class="dv">1900</span>, <span class="fl">1.0</span>]],
+                                      [[<span class="dv">1900</span>, <span class="fl">10.0</span>], [<span class="dv">1901</span>, <span class="fl">20.0</span>]]))</code></pre>
 <pre class="error"><code>---------------------------------------------------------------------------
 AssertionError                            Traceback (most recent call last)
 &lt;ipython-input-19-682d448d921e&gt; in &lt;module&gt;()
-      1 print &#39;left is shorter&#39;, diff_records([[1900, 1.0]],
-----&gt; 2                                       [[1900, 10.0], [1901, 20.0]])
+      1 print(&#39;left is shorter&#39;, diff_records([[1900, 1.0]],
+----&gt; 2                                       [[1900, 10.0], [1901, 20.0]]))
 
 &lt;ipython-input-16-d41327791c15&gt; in diff_records(left, right)
       4     Fails if the inputs are not for exactly corresponding years.
@@ -218,13 +218,13 @@ AssertionError                            Traceback (most recent call last)
       8     results = []
 
 AssertionError: Inputs have different lengths. left is shorter</code></pre>
-<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span> <span class="st">&#39;right is shorter&#39;</span>, diff_records([[<span class="dv">1900</span>, <span class="fl">1.0</span>], [<span class="dv">1901</span>, <span class="fl">2.0</span>]],
-                                       [[<span class="dv">1900</span>, <span class="fl">10.0</span>]])</code></pre>
+<pre class="sourceCode python"><code class="sourceCode python"><span class="dt">print</span>(<span class="st">&#39;right is shorter&#39;</span>, diff_records([[<span class="dv">1900</span>, <span class="fl">1.0</span>], [<span class="dv">1901</span>, <span class="fl">2.0</span>]],
+                                       [[<span class="dv">1900</span>, <span class="fl">10.0</span>]]))</code></pre>
 <pre class="error"><code>---------------------------------------------------------------------------
 AssertionError                            Traceback (most recent call last)
 &lt;ipython-input-20-a475e608dd70&gt; in &lt;module&gt;()
-      1 print &#39;right is shorter&#39;, diff_records([[1900, 1.0], [1901, 2.0]],
-----&gt; 2                                        [[1900, 10.0]])
+      1 print(&#39;right is shorter&#39;, diff_records([[1900, 1.0], [1901, 2.0]],
+----&gt; 2                                        [[1900, 10.0]]))
 
 &lt;ipython-input-16-d41327791c15&gt; in diff_records(left, right)
       4     Fails if the inputs are not for exactly corresponding years.
@@ -258,7 +258,7 @@ AssertionError: Inputs have different lengths. right is shorter</code></pre>
 <div class="panel-body">
 <p>Python includes a function called <code>enumerate</code> that’s often used in <code>for</code> loops. This loop:</p>
 <pre class="sourceCode python"><code class="sourceCode python"><span class="kw">for</span> (i, c) in <span class="dt">enumerate</span>(<span class="st">&#39;abc&#39;</span>):
-    <span class="dt">print</span> i, <span class="st">&#39;=&#39;</span>, c</code></pre>
+    <span class="dt">print</span>(i, <span class="st">&#39;=&#39;</span>, c)</code></pre>
 <p>prints:</p>
 <pre class="output"><code>0 = a
 1 = b

--- a/03-generalize.md
+++ b/03-generalize.md
@@ -23,8 +23,7 @@ def get_annual_mean_temp_by_country(country):
     if response.status_code != 200:
         print('Failed to get data:', response.status_code)
     else:
-        reader = io.StringIO(response.text)
-        wrapper = csv.reader(reader)
+        wrapper = csv.reader(response.text.strip().split(os.linesep))
         results = []
         for record in wrapper:
             if record[0] != 'year':
@@ -75,8 +74,7 @@ def get_annual_mean_temp_by_country(country):
     if response.status_code != 200:
         print('Failed to get data:', response.status_code)
     else:
-        reader = io.StringIO(response.text)
-        wrapper = csv.reader(reader)
+        wrapper = csv.reader(response.text.strip().split(os.linesep))
         results = []
         for record in wrapper:
             if record[0] != 'year':
@@ -109,8 +107,7 @@ def get_annual_mean_temp_by_country(country):
     response = requests.get(url)
     results = []
     if len(response.text) > 0:
-        reader = io.StringIO(response.text)
-        wrapper = csv.reader(reader)
+        wrapper = csv.reader(response.text.strip().split(os.linesep))
         for record in wrapper:
             if record[0] != 'year':
                 year = int(record[0])

--- a/03-generalize.md
+++ b/03-generalize.md
@@ -21,9 +21,9 @@ def get_annual_mean_temp_by_country(country):
     url = 'http://climatedataapi.worldbank.org/climateweb/rest/v1/country/cru/tas/year/' + country + '.csv'
     response = requests.get(url)
     if response.status_code != 200:
-        print 'Failed to get data:', response.status_code
+        print('Failed to get data:', response.status_code)
     else:
-        reader = cStringIO.StringIO(response.text)
+        reader = io.StringIO(response.text)
         wrapper = csv.reader(reader)
         results = []
         for record in wrapper:
@@ -38,7 +38,7 @@ This works:
 
 ~~~ {.python}
 canada = get_annual_mean_temp_by_country('CAN')
-print 'first five entries for Canada:', canada[:5]
+print('first five entries for Canada:', canada[:5])
 ~~~
 ~~~ {.output}
 first five entries for Canada: [[1901, -7.67241907119751], [1902, -7.862711429595947], [1903, -7.910782814025879], [1904, -8.155729293823242], [1905, -7.547311305999756]]
@@ -68,14 +68,14 @@ Let's check:
 def get_annual_mean_temp_by_country(country):
     '''Get the annual mean temperature for a country given its 3-letter ISO code (such as "CAN").'''
     url = 'http://climatedataapi.worldbank.org/climateweb/rest/v1/country/cru/tas/year/' + country + '.csv'
-    print 'url used is', url
+    print('url used is', url)
     response = requests.get(url)
-    print 'response code:', response.status_code
-    print 'length of data:', len(response.text)
+    print('response code:', response.status_code)
+    print('length of data:', len(response.text))
     if response.status_code != 200:
-        print 'Failed to get data:', response.status_code
+        print('Failed to get data:', response.status_code)
     else:
-        reader = cStringIO.StringIO(response.text)
+        reader = io.StringIO(response.text)
         wrapper = csv.reader(reader)
         results = []
         for record in wrapper:
@@ -86,7 +86,7 @@ def get_annual_mean_temp_by_country(country):
         return results
 
 latveria = get_annual_mean_temp_by_country('LTV')
-print 'number of records for Latveria:', len(latveria)
+print('number of records for Latveria:', len(latveria))
 ~~~
 ~~~ {.output}
 url used is http://climatedataapi.worldbank.org/climateweb/rest/v1/country/cru/tas/year/LTV.csv
@@ -109,7 +109,7 @@ def get_annual_mean_temp_by_country(country):
     response = requests.get(url)
     results = []
     if len(response.text) > 0:
-        reader = cStringIO.StringIO(response.text)
+        reader = io.StringIO(response.text)
         wrapper = csv.reader(reader)
         for record in wrapper:
             if record[0] != 'year':
@@ -118,8 +118,8 @@ def get_annual_mean_temp_by_country(country):
                 results.append([year, value])
     return results
 
-print 'number of records for Canada:', len(get_annual_mean_temp_by_country('CAN'))
-print 'number of records for Latveria:', len(get_annual_mean_temp_by_country('LTV'))
+print('number of records for Canada:', len(get_annual_mean_temp_by_country('CAN')))
+print('number of records for Latveria:', len(get_annual_mean_temp_by_country('LTV')))
 ~~~
 ~~~ {.output}
 number of records for Canada: 109
@@ -159,10 +159,10 @@ which we return at the end.
 To see if this function works, we can run a couple of tests on made-up data:
 
 ~~~ {.python}
-print 'one record:', diff_records([[1900, 1.0]],
-                                  [[1900, 2.0]])
-print 'two records:', diff_records([[1900, 1.0], [1901, 10.0]],
-                                   [[1900, 2.0], [1901, 20.0]])
+print('one record:', diff_records([[1900, 1.0]],
+                                  [[1900, 2.0]]))
+print('two records:', diff_records([[1900, 1.0], [1901, 10.0]],
+                                   [[1900, 2.0], [1901, 20.0]]))
 ~~~
 ~~~ {.output}
 one record: [[1900, -1.0]]
@@ -172,20 +172,20 @@ two records: [[1900, -1.0], [1901, -10.0]]
 That looks pretty good—but what about these cases?
 
 ~~~ {.python}
-print 'mis-matched years:', diff_records([[1900, 1.0]],
-                                         [[1999, 2.0]])
-print 'left is shorter', diff_records([[1900, 1.0]],
-                                      [[1900, 10.0], [1901, 20.0]])
-print 'right is shorter', diff_records([[1900, 1.0], [1901, 2.0]],
-                                       [[1900, 10.0]])
+print('mis-matched years:', diff_records([[1900, 1.0]],
+                                         [[1999, 2.0]]))
+print('left is shorter', diff_records([[1900, 1.0]],
+                                      [[1900, 10.0], [1901, 20.0]]))
+print('right is shorter', diff_records([[1900, 1.0], [1901, 2.0]],
+                                       [[1900, 10.0]]))
 ~~~
 ~~~ {.error}
 ---------------------------------------------------------------------------
 IndexError                                Traceback (most recent call last)
 <ipython-input-15-7582f56db8bf> in <module>()
       4                                       [[1900, 10.0], [1901, 20.0]])
-      5 print 'right is shorter', diff_records([[1900, 1.0], [1901, 2.0]],
-----> 6                                        [[1900, 10.0]])
+      5 print('right is shorter', diff_records([[1900, 1.0], [1901, 2.0]],
+----> 6                                        [[1900, 10.0]]))
 
 <ipython-input-13-67464343fd99> in diff_records(left, right)
       5     for i in range(num_years):
@@ -234,10 +234,10 @@ def diff_records(left, right):
 Do our "good" tests pass?
 
 ~~~ {.python}
-print 'one record:', diff_records([[1900, 1.0]],
-                                  [[1900, 2.0]])
-print 'two records:', diff_records([[1900, 1.0], [1901, 10.0]],
-                                   [[1900, 2.0], [1901, 20.0]])
+print('one record:', diff_records([[1900, 1.0]],
+                                  [[1900, 2.0]]))
+print('two records:', diff_records([[1900, 1.0], [1901, 10.0]],
+                                   [[1900, 2.0], [1901, 20.0]]))
 ~~~
 ~~~ {.output}
 one record: [[1900, -1.0]]
@@ -247,15 +247,15 @@ two records: [[1900, -1.0], [1901, -10.0]]
 What about our the three tests that we now expect to fail?
 
 ~~~ {.python}
-print 'mis-matched years:', diff_records([[1900, 1.0]],
-                                         [[1999, 2.0]])
+print('mis-matched years:', diff_records([[1900, 1.0]],
+                                         [[1999, 2.0]]))
 ~~~
 ~~~ {.error}
 ---------------------------------------------------------------------------
 AssertionError                            Traceback (most recent call last)
 <ipython-input-18-c101917a748e> in <module>()
-      1 print 'mis-matched years:', diff_records([[1900, 1.0]],
-----> 2                                          [[1999, 2.0]])
+      1 print('mis-matched years:', diff_records([[1900, 1.0]],
+----> 2                                          [[1999, 2.0]]))
 
 <ipython-input-16-d41327791c15> in diff_records(left, right)
      10         left_year, left_value = left[i]
@@ -268,15 +268,15 @@ AssertionError: Record 0 is for different years: 1900 vs 1999mis-matched years:
 ~~~
 
 ~~~ {.python}
-print 'left is shorter', diff_records([[1900, 1.0]],
-                                      [[1900, 10.0], [1901, 20.0]])
+print('left is shorter', diff_records([[1900, 1.0]],
+                                      [[1900, 10.0], [1901, 20.0]]))
 ~~~
 ~~~ {.error}
 ---------------------------------------------------------------------------
 AssertionError                            Traceback (most recent call last)
 <ipython-input-19-682d448d921e> in <module>()
-      1 print 'left is shorter', diff_records([[1900, 1.0]],
-----> 2                                       [[1900, 10.0], [1901, 20.0]])
+      1 print('left is shorter', diff_records([[1900, 1.0]],
+----> 2                                       [[1900, 10.0], [1901, 20.0]]))
 
 <ipython-input-16-d41327791c15> in diff_records(left, right)
       4     Fails if the inputs are not for exactly corresponding years.
@@ -288,15 +288,15 @@ AssertionError                            Traceback (most recent call last)
 AssertionError: Inputs have different lengths. left is shorter
 ~~~
 ~~~ {.python}
-print 'right is shorter', diff_records([[1900, 1.0], [1901, 2.0]],
-                                       [[1900, 10.0]])
+print('right is shorter', diff_records([[1900, 1.0], [1901, 2.0]],
+                                       [[1900, 10.0]]))
 ~~~
 ~~~ {.error}
 ---------------------------------------------------------------------------
 AssertionError                            Traceback (most recent call last)
 <ipython-input-20-a475e608dd70> in <module>()
-      1 print 'right is shorter', diff_records([[1900, 1.0], [1901, 2.0]],
-----> 2                                        [[1900, 10.0]])
+      1 print('right is shorter', diff_records([[1900, 1.0], [1901, 2.0]],
+----> 2                                        [[1900, 10.0]]))
 
 <ipython-input-16-d41327791c15> in diff_records(left, right)
       4     Fails if the inputs are not for exactly corresponding years.
@@ -330,7 +330,7 @@ Excellent: the assertions we've added will now alert us if we try to work with b
 >
 > ~~~ {.python}
 > for (i, c) in enumerate('abc'):
->     print i, '=', c
+>     print(i, '=', c)
 > ~~~
 >
 > prints:

--- a/05-makedata.md
+++ b/05-makedata.md
@@ -93,10 +93,6 @@ save_records('AUS', 'BRA', [[1, 2], [3, 4]])
 and then check that the right output file has been created.
 Since we are bound to have the country codes anyway (having used them to look up our data), this is as little extra work as possible.
 
-> ## Testing Output {.challenge}
->
-> Modify `save_records` so that it can be tested using `cStringIO`.
-
 > ## Deciding What to Check {.challenge}
 >
 > Should `save_records` check that every record in its input is the same length?

--- a/code/convert-to-function.py
+++ b/code/convert-to-function.py
@@ -1,6 +1,7 @@
 import requests
-import cStringIO
+import io
 import csv
+
 
 def get_country_temperatures(country):
     '''
@@ -11,7 +12,7 @@ def get_country_temperatures(country):
     base_url = 'http://climatedataapi.worldbank.org/climateweb/rest/v1/country/cru/tas/year/{0}.csv'
     actual_url = base_url.format(country)
     response = requests.get(actual_url)
-    reader = cStringIO.StringIO(response.text)
+    reader = io.StringIO(response.text)
     wrapper = csv.reader(reader)
     result = []
     for record in wrapper:
@@ -21,18 +22,21 @@ def get_country_temperatures(country):
             result.append([year, value])
     return result
 
+
 def test_nonexistent_country():
     values = get_country_temperatures('XYZ')
     assert len(values) == 0, 'Should not have succeeded for country XYZ'
+
 
 def test_canada():
     values = get_country_temperatures('CAN')
     assert len(values) > 0, 'Should have had data for country CAN'
 
+
 def run_tests():
     test_nonexistent_country()
     test_canada()
-    print 'all tests passed'
+    print('all tests passed')
 
 if __name__ == '__main__':
     run_tests()

--- a/code/convert-to-function.py
+++ b/code/convert-to-function.py
@@ -1,5 +1,5 @@
 import requests
-import io
+import os
 import csv
 
 
@@ -12,8 +12,7 @@ def get_country_temperatures(country):
     base_url = 'http://climatedataapi.worldbank.org/climateweb/rest/v1/country/cru/tas/year/{0}.csv'
     actual_url = base_url.format(country)
     response = requests.get(actual_url)
-    reader = io.StringIO(response.text)
-    wrapper = csv.reader(reader)
+    wrapper = csv.reader(response.text.strip().split(os.linesep))
     result = []
     for record in wrapper:
         if record[0] != 'year':

--- a/code/cstringio-demo.py
+++ b/code/cstringio-demo.py
@@ -1,6 +1,0 @@
-import cStringIO
-
-data = 'first\nsecond\nthird\n'
-reader = cStringIO.StringIO(data)
-for line in reader:
-    print line

--- a/code/csv-demo-2.py
+++ b/code/csv-demo-2.py
@@ -1,8 +1,8 @@
-import cStringIO
+import io
 import csv
 
-data = '1901,12.3\n1902,45.6\n1903,78.9\n'
-reader = cStringIO.StringIO(data)
+data = u'1901,12.3\n1902,45.6\n1903,78.9\n'
+reader = io.StringIO(data)
 wrapper = csv.reader(reader)
 for record in wrapper:
-    print record
+    print(record)

--- a/code/csv-demo-2.py
+++ b/code/csv-demo-2.py
@@ -1,8 +1,8 @@
-import io
+import os
 import csv
 
-data = u'1901,12.3\n1902,45.6\n1903,78.9\n'
-reader = io.StringIO(data)
-wrapper = csv.reader(reader)
+data = '1901,12.3\n1902,45.6\n1903,78.9\n'
+wrapper = csv.reader(data.strip().split(os.linesep))
+
 for record in wrapper:
     print(record)

--- a/code/csv-demo.py
+++ b/code/csv-demo.py
@@ -1,8 +1,8 @@
-import cStringIO
+import io
 import csv
 
-data = 'first\nsecond\nthird\n'
-reader = cStringIO.StringIO(data)
+data = u'first\nsecond\nthird\n'
+reader = io.StringIO(data)
 wrapper = csv.reader(reader)
 for record in wrapper:
-    print record
+    print(record)

--- a/code/csv-demo.py
+++ b/code/csv-demo.py
@@ -1,8 +1,8 @@
-import io
+import os
 import csv
 
 data = u'first\nsecond\nthird\n'
-reader = io.StringIO(data)
-wrapper = csv.reader(reader)
+wrapper = csv.reader(data.strip().split(os.linesep))
+
 for record in wrapper:
     print(record)

--- a/code/final.py
+++ b/code/final.py
@@ -1,5 +1,5 @@
 import requests
-import io
+import os
 import csv
 
 
@@ -25,8 +25,7 @@ def get_country_temperatures(country):
     base_url = 'http://climatedataapi.worldbank.org/climateweb/rest/v1/country/cru/tas/year/{0}.csv'
     actual_url = base_url.format(country)
     response = requests.get(actual_url)
-    reader = io.StringIO(response.text)
-    wrapper = csv.reader(reader)
+    wrapper = csv.reader(response.text.strip().split(os.linesep))
     result = []
     for record in wrapper:
         if record[0] != 'year':

--- a/code/final.py
+++ b/code/final.py
@@ -1,5 +1,5 @@
 import requests
-import cStringIO
+import io
 import csv
 
 
@@ -25,7 +25,7 @@ def get_country_temperatures(country):
     base_url = 'http://climatedataapi.worldbank.org/climateweb/rest/v1/country/cru/tas/year/{0}.csv'
     actual_url = base_url.format(country)
     response = requests.get(actual_url)
-    reader = cStringIO.StringIO(response.text)
+    reader = io.StringIO(response.text)
     wrapper = csv.reader(reader)
     result = []
     for record in wrapper:

--- a/code/final.py
+++ b/code/final.py
@@ -2,6 +2,7 @@ import requests
 import cStringIO
 import csv
 
+
 def compare_countries(left_country, right_country):
     '''
     Compare average surface temperatures for two countries over time.
@@ -9,10 +10,11 @@ def compare_countries(left_country, right_country):
     left_data = get_country_temperatures(left_country)
     right_data = get_country_temperatures(right_country)
     result = []
-    for ( (left_year, left_value), (right_year, right_value) ) in zip(left_country, right_country):
+    for ((left_year, left_value), (right_year, right_value)) in zip(left_country, right_country):
         assert left_year == right_year, 'Year mismatch: {0} vs {1}'.format(left_year, right_year)
         result.append([left_year, left_value - right_value])
     return result
+
 
 def get_country_temperatures(country):
     '''

--- a/code/get-data.py
+++ b/code/get-data.py
@@ -3,6 +3,6 @@ import requests
 url = 'http://climatedataapi.worldbank.org/climateweb/rest/v1/country/cru/tas/year/CAN.csv'
 response = requests.get(url)
 if response.status_code != 200:
-    print 'Failed to get data:', response.status_code
+    print('Failed to get data:', response.status_code)
 else:
-    print response.text
+    print(response.text)

--- a/code/get-parse-data-correctly.py
+++ b/code/get-parse-data-correctly.py
@@ -1,16 +1,19 @@
 import requests
-import cStringIO
+import io
 import csv
 
 url = 'http://climatedataapi.worldbank.org/climateweb/rest/v1/country/cru/tas/year/CAN.csv'
 response = requests.get(url)
 if response.status_code != 200:
-    print 'Failed to get data:', response.status_code
+    print('Failed to get data:', response.status_code)
 else:
-    reader = cStringIO.StringIO(response.text)
+    reader = io.StringIO(response.text)
     wrapper = csv.reader(reader)
+    results = []
     for record in wrapper:
         if record[0] != 'year':
             year = int(record[0])
             value = float(record[1])
-            print year, ':', value
+            results.append([year, value])
+    print('first five results')
+    print(results[:5])

--- a/code/get-parse-data-correctly.py
+++ b/code/get-parse-data-correctly.py
@@ -1,5 +1,5 @@
 import requests
-import io
+import os
 import csv
 
 url = 'http://climatedataapi.worldbank.org/climateweb/rest/v1/country/cru/tas/year/CAN.csv'
@@ -7,8 +7,7 @@ response = requests.get(url)
 if response.status_code != 200:
     print('Failed to get data:', response.status_code)
 else:
-    reader = io.StringIO(response.text)
-    wrapper = csv.reader(reader)
+    wrapper = csv.reader(response.text.strip().split(os.linesep))
     results = []
     for record in wrapper:
         if record[0] != 'year':

--- a/code/get-parse-data.py
+++ b/code/get-parse-data.py
@@ -1,15 +1,15 @@
 import requests
-import cStringIO
 import csv
+import io
 
 url = 'http://climatedataapi.worldbank.org/climateweb/rest/v1/country/cru/tas/year/CAN.csv'
 response = requests.get(url)
 if response.status_code != 200:
-    print 'Failed to get data:', response.status_code
+    print('Failed to get data:', response.status_code)
 else:
-    reader = cStringIO.StringIO(response.text)
+    reader = io.StringIO(response.text)
     wrapper = csv.reader(reader)
     for record in wrapper:
         year = int(record[0])
         value = float(record[1])
-        print year, ':', value
+        print(year, ':', value)

--- a/code/get-parse-data.py
+++ b/code/get-parse-data.py
@@ -1,14 +1,13 @@
 import requests
 import csv
-import io
+import os
 
 url = 'http://climatedataapi.worldbank.org/climateweb/rest/v1/country/cru/tas/year/CAN.csv'
 response = requests.get(url)
 if response.status_code != 200:
     print('Failed to get data:', response.status_code)
 else:
-    reader = io.StringIO(response.text)
-    wrapper = csv.reader(reader)
+    wrapper = csv.reader(response.text.strip().split(os.linesep))
     for record in wrapper:
         year = int(record[0])
         value = float(record[1])

--- a/code/io-demo.py
+++ b/code/io-demo.py
@@ -1,0 +1,6 @@
+import io
+
+data = 'first\nsecond\nthird\n'
+reader = io.StringIO(data)
+for line in reader:
+    print line

--- a/code/io-demo.py
+++ b/code/io-demo.py
@@ -1,6 +1,0 @@
-import io
-
-data = 'first\nsecond\nthird\n'
-reader = io.StringIO(data)
-for line in reader:
-    print line

--- a/code/parse-manually.py
+++ b/code/parse-manually.py
@@ -1,13 +1,13 @@
 input_data = '1901,12.3\n1902,45.6\n1903,78.9\n'
-print 'input data is:'
-print input_data
+print('input data is:')
+print(input_data)
 
 as_lines = input_data.split('\n')
-print 'as lines:'
-print as_lines
+print('as lines:')
+print(as_lines)
 
 for line in as_lines:
     fields = line.split(',')
     year = int(fields[0])
     value = float(fields[1])
-    print year, ':', value
+    print(year, ':', value)

--- a/code/parse-manually.py
+++ b/code/parse-manually.py
@@ -1,4 +1,4 @@
-input_data = '1901,12.3\n1902,45.6\n1903,78.9\n'
+input_data = '1901,12.3\n1902,45.6\n1903,78.9'
 print('input data is:')
 print(input_data)
 

--- a/code/wrapper-demo.py
+++ b/code/wrapper-demo.py
@@ -1,0 +1,8 @@
+import os
+
+data = 'first\nsecond\nthird\n'
+
+reader = data.strip().split(os.linesep)
+
+for line in reader:
+    print(line)

--- a/reference.html
+++ b/reference.html
@@ -35,7 +35,7 @@
 </ul>
 <h2 id="handling-csv-data"><a href="02-csv.html">Handling CSV Data</a></h2>
 <ul>
-<li>Use the <code>cStringIO</code> library to treat text as input or output files.</li>
+<li>Use the <code>io</code> library to treat text as input or output files.</li>
 <li>Use the <code>csv</code> library to read comma-separated values.</li>
 </ul>
 <h2 id="generalizing-and-handling-errors"><a href="03-generalize.html">Generalizing and Handling Errors</a></h2>
@@ -58,25 +58,25 @@
 <h2 id="glossary">Glossary</h2>
 <dl>
 <dt><span id="representational-state-transfer-(rest):">Representational State Transfer (REST):</span></dt>
-<dd>a set of patterns for sharing data on the web.
+<dd><p>a set of patterns for sharing data on the web.</p>
 </dd>
 <dt><span id="comma-separated-values-(csv):">comma-separated values (CSV):</span></dt>
-<dd>A common textual representation for tables in which the values in each row are separated by commas.
+<dd><p>A common textual representation for tables in which the values in each row are separated by commas.</p>
 </dd>
 <dt><span id="escape-sequence:">escape sequence:</span></dt>
-<dd>A sequence of characters used to represent another character. For example, the two-letter escape sequence <code>\n</code> represents a newline character in Python, while the multi-letter escape sequence <code>&amp;amp;</code> respresents an ampersand in HTML.
+<dd><p>A sequence of characters used to represent another character. For example, the two-letter escape sequence <code>\n</code> represents a newline character in Python, while the multi-letter escape sequence <code>&amp;amp;</code> respresents an ampersand in HTML.</p>
 </dd>
 <dt><span id="index:">index:</span></dt>
-<dd>A document or data set that contains information about, and pointers to, actual data sets. An index contains the metadata that makes actual data findable.
+<dd><p>A document or data set that contains information about, and pointers to, actual data sets. An index contains the metadata that makes actual data findable.</p>
 </dd>
 <dt><span id="silent-failure:">silent failure:</span></dt>
-<dd>Failing without producing any warning messages. Silent failures are hard to detect and debug.
+<dd><p>Failing without producing any warning messages. Silent failures are hard to detect and debug.</p>
 </dd>
 <dt><span id="status-code:">status code:</span></dt>
-<dd>A numerical value that indicates whether a function or other procedure succeeded, or if it failed, why.
+<dd><p>A numerical value that indicates whether a function or other procedure succeeded, or if it failed, why.</p>
 </dd>
 <dt><span id="unit-testing-tool:">unit testing tool:</span></dt>
-<dd>A software library and associated tool or tools that helps programmers write short tests for their code and run them systematically.
+<dd><p>A software library and associated tool or tools that helps programmers write short tests for their code and run them systematically.</p>
 </dd>
 </dl>
         </div>

--- a/reference.md
+++ b/reference.md
@@ -10,7 +10,7 @@ subtitle: Reference
 
 ## [Handling CSV Data](02-csv.html)
 
-*   Use the `cStringIO` library to treat text as input or output files.
+*   Use the `io` library to treat text as input or output files.
 *   Use the `csv` library to read comma-separated values.
 
 ## [Generalizing and Handling Errors](03-generalize.html)


### PR DESCRIPTION
- Code examples are now python2 and python3 compatible - 2to3 run over code 
- flake8 (from pyflakes) passes most tests for PEP8 style guidelines (ignored line length. two errors in final.py submitted as issue instead)
- print(foo, bar, baz) should ideally be refactored to "".format() style 
- code/\* run using Python 2.7.8 and Python 3.4.1, all working.
- cStringIO extension challenge removed - should likely be replaced with io challenge 
- cstringio-demo.py removed - replacement added
